### PR TITLE
PR 3: Agent prompt context injection (#7)

### DIFF
--- a/skills/obsidian-project-documentation/SKILL.md
+++ b/skills/obsidian-project-documentation/SKILL.md
@@ -168,7 +168,35 @@ Options:
 
 ### Step 4: Launch Documentation Agent
 
-Once you have all context, launch an `obsidian-project-documentation:manager` agent.
+Launch an `obsidian-project-documentation:manager` agent with a prompt that includes all of the following context variables. Every variable must be populated from the sources listed — do not leave any as empty or undefined.
+
+| Variable | Source |
+| -------- | ------ |
+| `{vault_path}` | `vault_path` from config |
+| `{project_name}` | Detected or user-supplied in Step 2–3 |
+| `{area}` | Detected or user-supplied in Step 2–3 |
+| `{description}` | Extracted or user-supplied in Step 2–3 |
+| `{cwd}` | Run `pwd` |
+| `{current_date}` | Run `date +%Y-%m-%d` |
+| `{auto_commit}` | `auto_commit` from config |
+| `{auto_push}` | `auto_push` from config |
+| `{git_enabled}` | `git_enabled` from config |
+| `{user_original_message}` | The exact message the User sent that triggered this skill |
+
+Use this prompt template, substituting each `{variable}` with its value:
+
+```text
+Vault Path: {vault_path}
+Project Name: {project_name}
+Project Area: {area}
+Description: {description}
+Working Directory: {cwd}
+Current Date: {current_date}
+auto_commit: {auto_commit}
+auto_push: {auto_push}
+git_enabled: {git_enabled}
+User's original message: {user_original_message}
+```
 
 ### Step 5: Report Results
 


### PR DESCRIPTION
## Summary

- **#7** Add explicit agent prompt template to `SKILL.md` Step 4, enumerating all context variables the launcher must pass to the manager agent and where to source each value

## Detail

Previously Step 4 said only "launch an agent" with no spec of what to include in the prompt. `manager.md` expects 10 context variables (`vault_path`, `project_name`, `area`, `description`, `cwd`, `current_date`, `auto_commit`, `auto_push`, `git_enabled`, `user_original_message`). Without explicit instructions, the launcher could pass an incomplete prompt, causing silent failures or incorrect note paths.

The fix adds a variable-source table and a concrete prompt template to copy-fill before spawning the agent.

## Test plan

- [ ] Trigger skill and verify the spawned agent receives a non-empty `{cwd}` (meta-documentation check works)
- [ ] Verify `{user_original_message}` is present in the agent context so intent is preserved
- [ ] Verify vault note is created at the correct path (confirms `{vault_path}` was passed)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)