### PR TITLE
PR 4: Agent frontmatter hardening (#9, #10, #11, #17)

### DIFF
--- a/agents/manager.md
+++ b/agents/manager.md
@@ -3,6 +3,10 @@ name: manager
 description: Use this agent when the user requests an action that should trigger 'documentation' behavior. This agent is usually triggered by the obsidian-project-documentation skill.
 model: sonnet
 color: purple
+tools: Read, Write, Edit, Bash, TodoWrite, AskUserQuestion, Glob, Grep
+maxTurns: 50
+background: true
+permissionMode: acceptEdits
 ---
 
 You are the Obsidian Project Documentation Manager agent. You are a meticulous project documentation manager specializing in technical documentation workflows for the User's projects. Your expertise lies in capturing decisions, maintaining project continuity, ensuring seemless handoffs between work sessions, and keep all documentation in a consistent structure within the User's Obsidian vault.


### PR DESCRIPTION
## Summary

Four additive-only changes to `agents/manager.md` frontmatter. No existing behaviour is removed.

- **#9** `tools: Read, Write, Edit, Bash, TodoWrite, AskUserQuestion, Glob, Grep` — explicit allowlist covering all 8 steps; prevents accidental sub-agent spawning
- **#10** `maxTurns: 50` — conservative ceiling for the 8-step workflow; prevents premature termination on large vaults
- **#11** `background: true` — enforces async execution at agent definition level, not just at the launcher call site
- **#17** `permissionMode: acceptEdits` — chosen over omitting or making it configurable; background agents that prompt for every vault write defeat the async design intent documented in CLAUDE.md

## Decision record for #17

The issue listed three options. `acceptEdits` was chosen because:
- The agent's entire purpose is autonomous documentation writes
- User approval of each file write is incompatible with background execution
- The tools allowlist already limits blast radius to file operations only (no shell escalation beyond Bash)

## Test plan

- [ ] Verify agent runs without prompting for file write approval on vault notes
- [ ] Verify agent runs without prompting for CLAUDE.md edits
- [ ] Confirm agent completes all 8 steps within 50 turns on a normal session
- [ ] Confirm agent does not attempt to spawn further sub-agents (tools allowlist enforced)

Closes #9
Closes #10
Closes #11
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)